### PR TITLE
deps: enable rustls feature for ureq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = "0.9"
 serde_json = "1.0"
 flexi_logger = { version = "0.25", features = ["is-terminal"] }
 thiserror = "1.0"
-ureq = { version = "3.0", default-features = false, features = ["gzip", "platform-verifier"] }
+ureq = { version = "3.0", default-features = false, features = ["gzip", "platform-verifier", "rustls"] }
 url = "2.3"
 
 [dev-dependencies]


### PR DESCRIPTION
Hey there, 

First- thanks for your great work on this tool!

I was setting it up on my machine, and ran into the following error:

```
$ scrape-ct-log -s 1 -n 10000 https://ct.googleapis.com/logs/crucible/
[2025-05-24 00:49:41.247602 +00:00] T[main] ERROR [src/bin/scrape-ct-log.rs:91] Scrape failed: HTTP request failed: TLS required, but transport is unsecured
```

(ref: [`Error::TlsRequired`](https://github.com/algesten/ureq/blob/50a1e902b234d8f41c3b7e553c84c648252de3c0/src/error.rs#L263))

I was able to fix it by enabling the [`rustls` feature](https://docs.rs/ureq/latest/ureq/#features) for ureq.